### PR TITLE
Extend timeout on SaveQuestion function in case API takes longer than expected

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -1745,6 +1745,7 @@ Resources:
       CodeUri: ./functions/save_question
       Description: Save Questions to S3 from the SQS queue, retrieve the full question from the Parliament API if the question or answer is not complete
       ReservedConcurrentExecutions: 2
+      Timeout: 30
       LoggingConfig:
         LogGroup: !Ref SaveQuestionFunctionLogGroup
       Layers:


### PR DESCRIPTION
*Description of changes:*

Extended the timeout on the SaveQuestion Lambda function as the Parliament API can sometimes take more than a few seconds to respond.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
