### PR TITLE
Disable cognito self service signup if not provisioning IDP

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10109,9 +10109,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001696",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001696.tgz",
-      "integrity": "sha512-pDCPkvzfa39ehJtJ+OwGT/2yvT2SbjfHhiIW2LWOAcMQ7BzwxT/XuyUp4OTOd0XFWA6BKw0JalnBHgSi5DGJBQ==",
+      "version": "1.0.30001743",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001743.tgz",
+      "integrity": "sha512-e6Ojr7RV14Un7dz6ASD0aZDmQPT/A+eZU+nuTNfjqmRrmkmQlnTNWH0SKmqagx9PeW87UVqapSurtAXifmtdmw==",
       "funding": [
         {
           "type": "opencollective",

--- a/template.yaml
+++ b/template.yaml
@@ -638,6 +638,11 @@ Resources:
           AllowedFirstAuthFactors:
             - WEB_AUTHN
             - PASSWORD
+      AdminCreateUserConfig:
+        AllowAdminCreateUserOnly: !If
+          - DeployIdpCondition
+          - False
+          - True
 
   CognitoUserPoolClient:
     Type: AWS::Cognito::UserPoolClient


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

If not provisioning the IDP then disable self service signup against the userpool.  The use case for not deploying the IDP is for federation with another IDP.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
